### PR TITLE
separated event and station lat lon

### DIFF
--- a/src/rrsm/rrsmi/fdsn/base_classes.py
+++ b/src/rrsm/rrsmi/fdsn/base_classes.py
@@ -286,11 +286,17 @@ class MotionDataStation(FdsnBaseClass):
     def get_magnitude(self):
         return self.string_to_decimal(self.event_magnitude, decimals=1)
 
-    def get_latitude(self):
+    def get_event_latitude(self):
         return self.string_to_decimal(self.event_latitude)
 
-    def get_longitude(self):
+    def get_event_longitude(self):
         return self.string_to_decimal(self.event_longitude)
+
+    def get_station_latitude(self):
+        return self.string_to_decimal(self.station_latitude)
+
+    def get_station_longitude(self):
+        return self.string_to_decimal(self.station_longitude)
 
     def get_epicentral_distance(self):
         return self.string_to_decimal(self.epicentral_distance)

--- a/src/rrsm/templates/event_details.html
+++ b/src/rrsm/templates/event_details.html
@@ -110,8 +110,8 @@
                 <p><b>Event depth [km]: </b>{{ motion_data.stations.0.event_depth }}</p>
             </div>
             <div class="col">
-                <p><b>Event latitude [°]: </b>{{ motion_data.stations.0.get_latitude }}</p>
-                <p><b>Event longitude [°]: </b>{{ motion_data.stations.0.get_longitude }}</p>
+                <p><b>Event latitude [°]: </b>{{ motion_data.stations.0.get_event_latitude }}</p>
+                <p><b>Event longitude [°]: </b>{{ motion_data.stations.0.get_event_longitude }}</p>
             </div>
         </div>
     </div>
@@ -149,7 +149,7 @@
                         <a href="{% url 'station_streams' motion_data.stations.0.event_id s.network_code s.station_code %}">
                             {{ s.network_code }} / {{ s.station_code }} {% if s.location_code %} / {{ s.location_code }}{% endif %}
                         </a>
-                        <small class="text-muted d-block">Lat: {{ s.get_latitude }}, Lon: {{ s.get_longitude }}</small>
+                        <small class="text-muted d-block">Lat: {{ s.get_station_latitude }}, Lon: {{ s.get_station_longitude }}</small>
                     </td>
                     <td>
                         {{ s.get_max_pga.0 }}

--- a/src/rrsm/templates/events.html
+++ b/src/rrsm/templates/events.html
@@ -76,7 +76,7 @@
     <td><a href="{% url 'event_details' s.get_public_id %}">{{ s.parse_origin_time }}</a></td>
     <td>
       <a href="#" onclick="focusEvent(parseFloat('{{ s.event_latitude }}'),parseFloat('{{ s.event_longitude }}'));">{{ s.get_flinn_engdahl }}</a>
-      <small class="text-muted d-block">Lat: {{ s.get_latitude }}, Lon: {{ s.get_longitude }}</small>
+      <small class="text-muted d-block">Lat: {{ s.get_event_latitude }}, Lon: {{ s.get_event_longitude }}</small>
     </td>
     <td><span id="mag_label-{{ s.get_public_id }}" class="badge">{{ s.get_magnitude }}</span></td>
     <td>{{ s.event_depth }}</td>

--- a/src/rrsm/templates/station_streams.html
+++ b/src/rrsm/templates/station_streams.html
@@ -103,8 +103,8 @@
                 <p><b>Station max PGA [cm/s<sup>2</sup>]: </b>{{ station_data.get_max_pga.0 }} ({{ station_data.get_max_pga.1 }})</p>
                 <p><b>Station max PGV [cm/s]: </b>{{ station_data.get_max_pgv.0 }} ({{ station_data.get_max_pgv.1 }})</p>
                 <p><b>Station epicentral distance [km]: </b>{{ station_data.get_epicentral_distance }}</p>
-                <p><b>Station latitude [°]: </b>{{ station_data.get_latitude }}</p>
-                <p><b>Station longitude [°]: </b>{{ station_data.get_longitude }}</p>
+                <p><b>Station latitude [°]: </b>{{ station_data.get_station_latitude }}</p>
+                <p><b>Station longitude [°]: </b>{{ station_data.get_station_longitude }}</p>
                 <p><b>Station elevation [m]: </b>{{ station_data.station_elevation }}</p>
             </div>
             <div class="col">
@@ -112,8 +112,8 @@
                 <p><b>Event time (UTC): </b>{{ station_data.parse_origin_time }}</p>
                 <p><b>Event magnitude: </b>{{ station_data.get_magnitude }} ({{ station_data.magnitude_type }})</p>
                 <p><b>Event depth [km]: </b>{{ station_data.event_depth }}</p>
-                <p><b>Event latitude [°]: </b>{{ station_data.get_latitude }}</p>
-                <p><b>Event longitude [°]: </b>{{ station_data.get_longitude }}</p>
+                <p><b>Event latitude [°]: </b>{{ station_data.get_event_latitude }}</p>
+                <p><b>Event longitude [°]: </b>{{ station_data.get_event_longitude }}</p>
             </div>
         </div>
     </div>

--- a/src/rrsm/templates/stations.html
+++ b/src/rrsm/templates/stations.html
@@ -70,7 +70,7 @@
           <td>{{ s.get_magnitude }}</td>
           <td>{{ s.network_code }}.{{ s.station_code }}</td>
           <td>{{ s.get_flinn_engdahl }}
-            <small class="text-muted d-block">Lat: {{ s.get_latitude }}, Lon: {{ s.get_longitude }}</small>
+            <small class="text-muted d-block">Lat: {{ s.get_event_latitude }}, Lon: {{ s.get_event_longitude }}</small>
           </td>
           <td>{{ s.epicentral_distance }}</td>
           <td>{{ s.get_max_pga.0 }}</td>


### PR DESCRIPTION
Latitude and longitude were always based on the event, even if the station latitude was needed for certain page views.
Created separate `get_latitude` and `get_longitude` functions for events and stations and changed the page views.